### PR TITLE
Create release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+ 
+  workflow_dispatch:
+    inputs:
+      is-latest:
+        description: 'Is latest version'
+        required: false
+        default: true
+        type: boolean
+        
+jobs:
+  add-tag:
+    name: Release action
+    uses: JanCodeLab/workflows/.github/workflows/add-tag-from-package.yml@latest
+    with:
+      version-file: './package.json'
+      is-latest: ${{ github.event_name == 'push' || github.event.inputs.is-latest == 'true' }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process. The workflow is triggered on pushes to the `main` branch and can also be manually triggered with a `workflow_dispatch` event. The most important changes include the addition of a new workflow file and the configuration of job inputs and conditions.

### New GitHub Actions workflow for releases:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R22): Added a new workflow named "Release" that triggers on pushes to the `main` branch and can also be manually triggered with a `workflow_dispatch` event. The workflow includes a job that uses the `add-tag-from-package.yml` action to manage version tags based on the `package.json` file.